### PR TITLE
Add app navigation buttons to shared note page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.541.0",
         "next": "^15.5.0",
+        "quill-delta-to-html": "^0.12.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "remark": "^15.0.1",
@@ -777,6 +778,8 @@
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
+    "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
+
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
@@ -974,6 +977,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "quill-delta-to-html": ["quill-delta-to-html@0.12.1", "", { "dependencies": { "lodash.isequal": "^4.5.0" } }, "sha512-QhpeMk9+5ge3HYbL5A0Ewz3pXCsbemqGvIF/kw5D6D4V68AtcUp7yt9xNUkzOk/0IQz43hKy3IkzBzRhLIE+oA=="],
 
     "react": ["react@19.1.1", "", {}, "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ms-bridge",
-    "version": "1.0.0",
+    "version": "2.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ms-bridge",
-            "version": "1.0.0",
+            "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
                 "@heroicons/react": "^2.2.0",

--- a/src/app/s/[shareId]/page.tsx
+++ b/src/app/s/[shareId]/page.tsx
@@ -119,18 +119,19 @@ export default function SharedNotePage({ params }: { params: Promise<{ shareId: 
   }, [shareId]);
 
   // Handlers for app navigation
-  const openInApp = useCallback(() => {
-    if (!webUrl) return;
-    
-    if (typeof navigator !== 'undefined' && navigator.userAgent.includes('android')) {
-      // Android intent URL with fallback
-      const intentUrl = `intent://s/${shareId}#Intent;scheme=https;package=com.syntaxlab.msbridge;S.browser_fallback_url=${encodeURIComponent(webUrl)};end`;
-      window.location.href = intentUrl;
-    } else {
-      // For non-Android, just navigate to web URL
-      window.location.href = webUrl;
-    }
-  }, [webUrl, shareId]);
+const openInApp = useCallback(() => {
+  if (!shareId || !webUrl) return;
+  const ua = (typeof navigator !== 'undefined' ? navigator.userAgent : '').toLowerCase();
+
+  if (ua.includes('android')) {
+    const intent = `intent://s/${shareId}`
+      + `#Intent;scheme=https;action=android.intent.action.VIEW;category=android.intent.category.BROWSABLE;`
+      + `package=com.syntaxlab.msbridge;S.browser_fallback_url=${encodeURIComponent(webUrl)};end`;
+    window.location.href = intent;
+    return;
+  }
+  window.location.href = webUrl;
+}, [shareId, webUrl]);
 
   const continueOnWeb = useCallback(() => {
     if (!webUrl) return;


### PR DESCRIPTION
Introduces 'Open in App' and 'Continue on Web' buttons to the shared note page, allowing users to open notes directly in the MS Bridge app (with Android intent support) or continue viewing on the web. Refactors shareId handling and memoizes webUrl for improved navigation logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Open in App” and “Continue on Web” header buttons for shared notes when a link ID is present.
  * Android deep-linking opens the app with a safe browser fallback; other platforms continue on the web.
  * Improved client-side navigation flow for shared links.

* **Bug Fixes**
  * Clearer error messages: distinguishes unavailable/disabled links, access-restricted links, and provides a generic fallback for other failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->